### PR TITLE
added second event for Istanbul, Turkey

### DIFF
--- a/_data/events/istanbul2.json
+++ b/_data/events/istanbul2.json
@@ -1,0 +1,19 @@
+{
+  "title": "GDCR17 Festival at Istanbul",
+  "url": "https://www.meetup.com/Software-Craftsmanship-Turkey/events/242432406/",
+  "moderators": [
+    "@lemiorhan",
+    "@scturkey",
+    "@agileturkey"
+  ],
+  "location": {
+    "city": "Istanbul",
+    "country": "Turkey",
+    "coordinates": {
+      "latitude": 41.0285741,
+      "longitude": 29.1150436
+    },
+    "utcOffset": 3,
+    "timezone": "Europe/Istanbul"
+  }
+}


### PR DESCRIPTION
We would like to register a second event for GDCR17 to Istanbul. 