### PR TITLE
Navigation styling for all screen sizes

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,24 +1,46 @@
 <div class="navbar">
 
   <div class="navbar-inner">
-    <a href="{{ site.baseurl }}/">
-      <img src="/images/global-day-iso.png" height=40 alt="Coderetreat logo" style="border-radius: 50px">
-    </a>
-    <b>
- 
-    <a href="{% link register-event.md %}"      >Register a<br>Coderetreat</a>
-    <a href="{% link pages/hosting/hosts.md %}" >Hosting and Facilitating </a>
-    <a href="{% link pages/training.md %}"      >Training                 </a>
-    <a href="{% link pages/blog.md %}"          >Blog                     </a>
-    <a href="{% link pages/videos.html %}"      >Videos                   </a>
+    <div class="logo-nav-container">
+      <a class="logo" href="{{ site.baseurl }}/">
+        <img src="/images/global-day-iso.png" height=40 alt="Coderetreat logo" style="border-radius: 50px">
+      </a>
+      <a href="#" id='nav-click'>
+        <b class='menu-word'>Menu</b>
+        <button class="hamburger" id='hamburger'>
+          <span>toggle menu</span>
+        </button>
+      </a>
+      <b class="nav-links" id="mobile-nav">
+        <a href="{% link register-event.md %}"      >Register a Coderetreat</a>
+        <a href="{% link pages/hosting/hosts.md %}" >Hosting and Facilitating </a>
+        <a href="{% link pages/training.md %}"      >Training</a>
+        <a href="{% link pages/blog.md %}"          >Blog</a>
+        <a href="{% link pages/videos.html %}"      >Videos</a>
+      </b>
+    </div>
 
-    <a href="http://slack.softwarecraftsmanship.org">Join us on <br><img src="/images/Slack_Mark.svg" style="height:1.5em; vertical-align:top"> Slack</a>
-    <a href="https://twitter.com/coderetreat">Follow us on <br><img src="/images/Twitter_bird_logo_2012.svg" style="height:1.3em; vertical-align:top"> Twitter</a>
+    <b class="social-media-links">
+      <div>
+        <a href="http://slack.softwarecraftsmanship.org">Join us on <img src="/images/Slack_Mark.svg" style="height:1.5em; vertical-align:top" alt="Slack logo"> Slack</a>
+      </div>
+      <div>
+        <a href="https://twitter.com/coderetreat">Follow us on <img src="/images/Twitter_bird_logo_2012.svg" style="height:1.3em; vertical-align:top" alt="Twitter logo"> Twitter</a>
+      </div>
     </b>
+
   </div>
 
   <a href="https://github.com/coderetreat/coderetreat.github.io">
     <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" alt="Fork me on GitHub">
   </a>
-
 </div>
+
+<script type='text/javascript'>
+  const mobileNav = document.getElementById('mobile-nav');
+  const hamburger = document.getElementById('hamburger');
+  document.getElementById('nav-click').addEventListener('click', function(ev) {
+    ev.preventDefault();
+    mobileNav.classList.toggle('expand');
+  }, false);
+</script>

--- a/_sass/navigation.scss
+++ b/_sass/navigation.scss
@@ -1,47 +1,211 @@
 $navbar-height: 3*$gutter;
 $navbar-padding: $gutter/2;
 
+.container {
+  margin-top: $navbar-height;
+}
+
 .navbar {
   padding: $navbar-padding 0;
   position: fixed;
   top: 0;
   width: 100%;
   background-color: $light;
-  .navbar-inner {
-    @include outer-container;
-    a {
-      display: block;
-      @include span-columns(1 of 8);
-      text-align: left;
-    }
-    .logo img { max-height: $navbar-height - 2*$navbar-padding; }
-  }
   box-shadow: 0 0 8px 0 black;
   z-index: 50;
   height: $navbar-height;
-
-  @include media($tablet) {
-    font-size: 1.2em;
-    .navbar-inner {
-      a {
-        @include span-columns(3 of 14);
-        &:nth-child(2) { @include shift(0); }
-        padding-top: .2em;
-      }
-    }
-    padding: 0 $gutter;
+  a {
+    cursor: pointer;
   }
-  @include media($mobile) {
-    .navbar-inner {
-      a {
-        text-align: left;
-        @include span-columns(1 of 4);
-        &:nth-child(2) { @include shift(0); }
-      }
+}
+
+.navbar-inner {
+  display: flex;
+  @include outer-container;
+  .logo {
+    display: block;
+    text-align: left;
+    flex-grow: 1;
+  }
+  .logo img { max-height: $navbar-height - 2*$navbar-padding; }
+  button {
+    display: none;
+  }
+}
+
+.menu-word {
+  display: none;
+}
+
+.logo-nav-container {
+  display: flex;
+  flex-grow: 6;
+}
+
+.nav-links {
+  display: flex;
+  flex-wrap: nowrap;
+  flex-grow: 6;
+  a {
+    flex-grow: 1;
+    margin-top: 10px;
+  }
+}
+
+.social-media-links {
+  display: flex;
+  flex-grow: 2;
+  div {
+    flex-grow: 1;
+  }
+  a {
+    display: inline-block;
+    max-width: 100px;
+  }
+}
+
+@media only screen and (max-width: 1250px) {
+  .navbar-inner {
+    display: block;
+    padding-left: 20px;
+  }
+  .logo-nav-container {
+    max-width: 700px;
+  }
+  .nav-links {
+    a {
+      margin-top: -5px;
+    }
+  }
+  .social-media-links {
+    text-align: right;
+    width: 400px;
+    position: absolute;
+    right: 100px;
+    margin-top: -10px;
+    a {
+      max-width: none;
     }
   }
 }
 
-.container {
-  margin-top: $navbar-height;
+@media only screen and (max-width: 900px) {
+  .navbar-inner {
+    button {
+      display: block;
+    }
+  }
+  .menu-word {
+    margin-left: 50px;
+    color: $green;
+    font-size: 1.2em;
+    display: block;
+    margin-top: 10px;
+    margin-right: 20px;
+  }
+  .hamburger {
+    position: absolute;
+    top: 0;
+    left: 165px;
+    overflow: hidden;
+    margin: 0;
+    padding: 0;
+    width: 70px;
+    height: 67px;
+    font-size: 0;
+    text-indent: -9999px;
+    box-shadow: none;
+    border: none;
+    cursor: pointer;
+    background-color: inherit;
+    &:focus {
+      outline: none;
+    }
+    span {
+      display: block;
+      position: absolute;
+      top: 35px;
+      left: 18px;
+      right: 18px;
+      height: 5px;
+      background: $green;
+      transition: transform 0.3s;
+      &::before, &::after {
+        position: absolute;
+        display: block;
+        left: 0;
+        width: 100%;
+        height: 5px;
+        background-color: $green;
+        content: "";
+      }
+      &::before {
+        top: -10px;
+      }
+      &::after {
+        bottom: -10px;
+      }
+    }
+  }
+
+  .logo-nav-container {
+    max-width: 90%;
+  }
+
+  .nav-links {
+    visibility: hidden;
+    height: 0;
+    transition: height 0.3s ease-out;
+    &.expand {
+      visibility: visible;
+      height: 220px;
+      flex-direction: column;
+      background-color: $light;
+      padding-left: 10px;
+      font-size: 20px;
+      margin-top: 60px;
+      padding-top: 15px;
+      width: 489px;
+      a:last-child {
+        padding-bottom: 0;
+      }
+    }
+  }
+
+  .navbar-inner {
+    display: flex;
+  }
+
+  .social-media-links {
+    width: 300px;
+    right: 150px;
+    margin-top: 0;
+    display: flex;
+    flex-grow: 2;
+    div {
+      flex-grow: 1;
+    }
+    a {
+      display: inline-block;
+      max-width: 100px;
+    }
+  }
+}
+
+@media only screen and (max-width: 700px) {
+  .navbar {
+    font-size: 15px;
+  }
+
+  .social-media-links {
+    display: none;
+  }
+
+  .menu-word {
+    display: none;
+  }
+
+  .hamburger {
+    left: 41%;
+  }
 }


### PR DESCRIPTION
Hi @rradczewski !
I saw that you created an issue for mobile nav styling, so I took the liberty to improve it a bit. Have a look and see what you think. I followed the example from the Bootstrap website, as you suggested.

I'm not using iPad or phone sizes for my media queries but just pixel sizes, related to the design. So when I thought it looked a bit crowded, I created a media query and changed the design a bit. 
It's not perfect, but I guess it addresses the main issue of the nav links coming out of the top bar.

Let me know what you think!
Rabea

<img width="481" alt="screen shot 2017-08-27 at 14 44 50" src="https://user-images.githubusercontent.com/8995723/29750362-637b2a2e-8b36-11e7-9698-043ddcc76064.png">
<img width="807" alt="screen shot 2017-08-27 at 14 44 44" src="https://user-images.githubusercontent.com/8995723/29750363-655e578a-8b36-11e7-86f2-00bf3a5c8ac3.png">
<img width="1074" alt="screen shot 2017-08-27 at 14 44 35" src="https://user-images.githubusercontent.com/8995723/29750367-68198ca6-8b36-11e7-8eab-ef8431e3f1f7.png">
<img width="1283" alt="screen shot 2017-08-27 at 14 44 24" src="https://user-images.githubusercontent.com/8995723/29750368-6a96ef8c-8b36-11e7-852c-37b378ecc1c0.png">
