### PR TITLE
Add event data for Morgantown

### DIFF
--- a/_data/events/Morgantown.json
+++ b/_data/events/Morgantown.json
@@ -1,0 +1,17 @@
+{
+  "title": "GDCR17 - Morgantown",
+  "url": "https://www.meetup.com/morgantown-codes/events/242954005/",
+  "moderators": [
+    "@praisechaos"
+  ],
+  "location": {
+    "city": "Morgantown, WV",
+    "country": "USA",
+    "coordinates": {
+      "latitude": 39.6532451,
+      "longitude": -79.9420172
+    },
+    "utcOffset": -4,
+    "timezone": "America/New_York"
+  }
+}


### PR DESCRIPTION
This commit adds event information for an event at the realtor.com offices in Morgantown, WV. It's been a few years since I ran an event in the area, and I'm looking forward to doing it again! Thanks!