### PR TITLE
Issue #62: separate facilitator names with comma in event list.

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -21,9 +21,7 @@ layout: default
         <td>{{ event.location.city }}</td>
         <td><a href="{{ event.url }}">{{ event.title }}</a></td>
         <td>
-          {% for moderator in event.moderators %}
-            {{ moderator }}
-          {% endfor %}
+          {{ event.moderators | join: ', '}}
         </td>
       </tr>
     {% endfor %}


### PR DESCRIPTION
Now joining facilitator names on the events page with `, `.

Here's what it looks like now, one row with regular names, one with handles:
<img width="900" alt="screen shot 2017-09-09 at 7 46 59 pm" src="https://user-images.githubusercontent.com/1082328/30244971-b2566188-9598-11e7-9b6a-985835aa732f.png">

Thanks!