### PR TITLE
Add tests to disallow additionalAttributes

### DIFF
--- a/test/invalid_events/coordinatesUnexpectedKey.json
+++ b/test/invalid_events/coordinatesUnexpectedKey.json
@@ -1,0 +1,15 @@
+{
+  "title": "GDCR17 in Berlin",
+  "url": "https://www.meetup.com/Software-Craftsmanship-Berlin/",
+  "location": {
+    "utcOffset": 2,
+    "timezone": "Europe/Berlin",
+    "city": "Berlin",
+    "country": "Germany",
+    "coordinates": {
+      "latitude": 52.5250871,
+      "longitude": 13.3672133,
+      "unexpectedKey": "something undesireable"
+    }
+  }
+}

--- a/test/invalid_events/locationUnexpectedKey.json
+++ b/test/invalid_events/locationUnexpectedKey.json
@@ -1,0 +1,10 @@
+{
+  "title": "GDCR17 in Berlin",
+  "url": "https://www.meetup.com/Software-Craftsmanship-Berlin/",
+  "location": {
+    "timezone": "Europe/Berlin",
+    "city": "Berlin",
+    "country": "Germany"
+  },
+  "unexpectedKey": "something undesireable"
+}

--- a/test/invalid_events/topLevelUnexpectedKey.json
+++ b/test/invalid_events/topLevelUnexpectedKey.json
@@ -1,0 +1,10 @@
+{
+  "title": "GDCR17 in Berlin",
+  "url": "https://www.meetup.com/Software-Craftsmanship-Berlin/",
+  "location": {
+    "timezone": "Europe/Berlin",
+    "city": "Berlin",
+    "country": "Germany"
+  },
+  "unexpectedKey": "something undesireable"
+}

--- a/test/validate_events.test.js
+++ b/test/validate_events.test.js
@@ -68,4 +68,16 @@ describe('Invalid events given in /test/invalid_events', () => {
       })
     );
   });
+
+  describe('that have unexpected keys: ', () => {
+    const eventsWithUnexpectedKeys = glob.sync(path.resolve(__dirname, './invalid_events/')
+      + '/*UnexpectedKey.json');
+
+    eventsWithUnexpectedKeys.forEach(file =>
+      it(path.basename(file) + ' does not validate', () => {
+        const result = validationResults(JSON.parse(fs.readFileSync(file)));
+        expect(result.errors.length).toBeGreaterThan(0);
+      })
+    );
+  });
 });


### PR DESCRIPTION
This tests `additionalAttributes` at all three levels the schema currently disallows them.