### PR TITLE
Fix dead link to 'Hosts' page

### DIFF
--- a/_includes/hosting.html
+++ b/_includes/hosting.html
@@ -4,7 +4,7 @@
   <div class="host-contents">
   <div class="host-aside">
     Missed the Global Day of Coderetreat because there wasn't an event near you?
-    <a href="/hosts" target="_blank">Host your own!</a>
+    <a href="{% link pages/hosting/hosts.md %}" target="_blank">Host your own!</a>
     <p>
       Coderetreats are run by volunteers who want to help out
       their local developer community.
@@ -27,11 +27,10 @@
         developers in their community improve their craft.
       </p>
      </div>
- 
+
      <div class="overlay"></div>
 
    </div>
   </div>
-  <a class="button" href="/pages/hosting/hosts">Learn about hosting and facilitating</a>
+  <a class="button" href="{% link pages/hosting/hosts.md %}">Learn about hosting and facilitating</a>
 </section>
-


### PR DESCRIPTION
- Assuming: `/pages/hosting/hosts` was the intended target.
- Notice: _Diff_ also handles two minor formatting issues present in the file.