### PR TITLE
Show upcoming trainings chronologically

### DIFF
--- a/pages/training.md
+++ b/pages/training.md
@@ -11,7 +11,7 @@ layout: default
       <div class="tip">Tip: visit the event page to see the date and time converted to your local timezone.</div>
 
       <div class="Umd">
-        {% for training in site.data.trainings.trainings-2017 %}
+        {% for training in site.data.trainings.trainings-2017 reversed %}
           {% capture posttime %}{{training.dateTime | date: '%s'}}{% endcapture %}
           {% if posttime > nowunix %}
             {% include session.html %}


### PR DESCRIPTION
## Context

When visiting the trainings page, users are forced to scroll down in order to find the next upcoming training session. 

Probably sorting them chronologically (what this change does) is a more convenient way to present the info to the users.

## Screenshots

Before:

![screen shot 2017-10-11 at 09 33 11](https://user-images.githubusercontent.com/1498567/31428135-0b4fbbb0-ae6a-11e7-85f8-0328c9098679.png)

After:

![screen shot 2017-10-11 at 09 32 16](https://user-images.githubusercontent.com/1498567/31428140-1130dfc8-ae6a-11e7-85de-ef8997668ffe.png)

Note: Dead link to Eric's pic has been already handled @ #150.