### PR TITLE
Add GDCR 2017 Melbourne hosted by Thoughtworks

### DIFF
--- a/_data/events/Melbourne.json
+++ b/_data/events/Melbourne.json
@@ -1,0 +1,17 @@
+{
+  "title": "GDCT17 Melbourne",
+  "url": "https://www.eventbrite.co.uk/e/global-day-of-code-retreat-tickets-39378388821",
+  "moderators": [
+    "@thelukemccarthy"
+  ],
+  "location": {
+    "city": "Melbourne",
+    "country": "Australia",
+    "coordinates": {
+      "latitude": -37.8166797,
+      "longitude": 144.9617733
+    },
+    "utcOffset": 10,
+    "timezone": "Australia/Melbourne"
+  }
+}


### PR DESCRIPTION
Thoughtworks would like to host a code retreat in Melbourne.