### PR TITLE
Clarify the steps for registering an event on coderetreat.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This year, registering your event at coderetreat.org is easier than it has ever 
    ```
 
 
-3. Submit a pull request:
+3. Run the tests locally before creating the pull request:
 
    ```sh
    cd coderetreat.github.io/ # Change into the repository
@@ -47,12 +47,15 @@ This year, registering your event at coderetreat.org is easier than it has ever 
    ```
 
 
-4. Travis-CI will automatically verify that your JSON file is valid (it should show up [here](https://travis-ci.org/coderetreat/coderetreat.github.io/pull_requests) in the test output) 
+4. Submit a pull request from Github. Be sure your PR title is clear. 
+
+
+5. Travis-CI will automatically verify that your JSON file is valid (it should show up [here](https://travis-ci.org/coderetreat/coderetreat.github.io/pull_requests) in the test output) 
 
    *If you would like to  to run the verification of the JSON file locally, then you must have NodeJS installed on your machine.*
 
 
 
-5. The Coderetreat coordinators will then merge your request as soon as possible.
+6. The Coderetreat coordinators will then merge your request as soon as possible.
 
 


### PR DESCRIPTION
The description was not fully clear; after "Submit a pull request:" there was info on how to run the tests locally, giving the impression those commands would open a pull request. I think it is clearer now, please do confirm 😄

Cheers!
@erorcodes