### PR TITLE
Update Cambridge to group with other USA cities

### DIFF
--- a/_data/events/Cambridge.json
+++ b/_data/events/Cambridge.json
@@ -6,7 +6,7 @@
   ],
   "location": {
     "city": "Cambridge",
-    "country": "United States",
+    "country": "United States of America",
     "coordinates": {
       "latitude": 42.3626831,
       "longitude": -71.087541


### PR DESCRIPTION
It was set as "United States" but it seems that the other US events are "United States of America". This was causing both to show up in the drop-down.