### PR TITLE
Registering Sophia Antipolis for GDCR'17

### DIFF
--- a/_data/events/SophiaAntipolis.json
+++ b/_data/events/SophiaAntipolis.json
@@ -1,0 +1,17 @@
+{
+  "title": "GDRC17 in Sophia Antipolis",
+  "url": "https://www.eventbrite.fr/e/billets-global-day-of-code-retreat-a-polytechnice-39340819450",
+  "moderators": [
+    "@mosser"
+  ],
+  "location": {
+    "city": "Sophia Antipolis",
+    "country": "France",
+    "coordinates": {
+      "latitude": 43.614738,
+      "longitude": 7.071720
+    },
+    "utcOffset": 2,
+    "timezone": "Europe/Paris"
+  }
+}


### PR DESCRIPTION
Hi, 

like last year, we plan to host the GDCR in our campus, a joint effort between the local software craftmanship community and the University of Nice.