### PR TITLE
Added Rzeszow and Gdansk GDCR 2018 events in Poland 

### DIFF
--- a/_data/events_gdcr2018/Gdansk.json
+++ b/_data/events_gdcr2018/Gdansk.json
@@ -1,0 +1,21 @@
+{
+  "title": "Global Day of Coderetreat - Gdansk 2018",
+  "url": "https://softwaretalks.pl/wydarzenia/global-day-coderetreat-3/",
+  "moderators": [
+    "Krzysztof Kakol",
+    "Iga Zacher-Czempa"
+  ],
+  "sponsors": [
+    "@pgssoftware"
+  ],
+  "location": {
+    "city": "Gdansk",
+    "country": "Poland",
+    "coordinates": {
+      "latitude": 54.3605361,
+      "longitude": 18.6450142
+    },
+    "utcOffset": 2,
+    "timezone": "Europe/Warsaw"
+  }
+}

--- a/_data/events_gdcr2018/Rzeszow.json
+++ b/_data/events_gdcr2018/Rzeszow.json
@@ -1,0 +1,21 @@
+{
+  "title": "Global Day of Coderetreat - Rzeszow 2018",
+  "url": "https://softwaretalks.pl/wydarzenia/global-day-coderetreat-4/",
+  "moderators": [
+    "Mateusz Dronka",
+    "Sylwester Zimon"
+  ],
+  "sponsors": [
+    "@pgssoftware"
+  ],
+  "location": {
+    "city": "Rzeszow",
+    "country": "Poland",
+    "coordinates": {
+      "latitude": 50.0492628,
+      "longitude": 22.006778
+    },
+    "utcOffset": 2,
+    "timezone": "Europe/Warsaw"
+  }
+}


### PR DESCRIPTION
Adding two events in Rzeszow and Gdansk (Poland) organised by PGS Software company.