### PR TITLE
Update hosting tools for #gdcr18

### DIFF
--- a/hosts/embedded.html
+++ b/hosts/embedded.html
@@ -54,13 +54,12 @@
       <h1>Twitter</h1>
         <div class="row">
           <div class="col-lg-6 col-sd-12">
-            <p>Engaging with all the other events over the world is what makes the GDCR magical. This year, instead of the <i>CodeRetreat Live!</i> app, we're trying to use Twitter to let you share your current status</p>
             <p>
               You're of course free to not use the suggested tweets below,
-              however, we'd appreciate if you would use both the tags <strong>#gdcr17</strong> and <strong>#live</strong>
+              however, we'd appreciate if you would use both the tags <strong>#gdcr18</strong> and <strong>#live</strong>
               when you update the current session you're running and when you clock in or -out.
             </p>
-            <p>This way, you can search for other locations' updates with the search term <a href="https://twitter.com/search?f=tweets&q=%23gdcr17%20AND%20%23live"><code>#gdcr17 AND #live</code></a></p>
+            <p>This way, you can search for other locations' updates with the search term <a href="https://twitter.com/search?f=tweets&q=%23gdcr18%20AND%20%23live"><code>#gdcr17 AND #live</code></a></p>
             <blockquote><i><small>
               <i class="fa fa-lightbulb-o">&nbsp;</i>There are some suggested constraints in auto complete.
               If you're interested in more constraints for your sessions, please have a look in the chapter "Other Activities" of

--- a/hosts/embedded.html
+++ b/hosts/embedded.html
@@ -136,7 +136,7 @@
       <div class="row">
         <div class="col-md-6">
           <h1>Video Booths</h1>
-          <p>Please bring a proper camera (and if possible audio setup) to your event. We have setup a few video booths using <strong>appear.in</strong> to bring together groups from all over the world</p>
+          <p>Please bring a proper camera (and if possible audio setup) to your event. We have setup a few video booths using <strong>meet.jit.si</strong> to bring together groups from all over the world</p>
           <p><strong>If possible, it would be great if you could idle in the booth for your timezone.</strong></p>
           <blockquote><i><small>
             <i class="fa fa-lightbulb-o">&nbsp;</i>It is fun to join channels in vastly different timezones!
@@ -160,7 +160,7 @@
           <h2>Your Booth</h2>
           <p><strong><a target="_blank" data-bind="attr: { href: selectedBoothVideoUrl }, text: selectedBoothVideoUrl"></a></strong>
           <p>Full? Try <a href="#" data-bind="click: increaseBoothNumber">the next one in this timezone category</a> (or <a href="#" data-bind="click: decreaseBoothNumber">go back</a>)</p>
-          <iframe id="videoboothIframe" src="about:blank" data-bind="attr { src: selectedBoothVideoUrl }" frameborder="0" width="100%" height="600px"></iframe>
+          <iframe id="videoboothIframe" allow="microphone; camera" src="about:blank" data-bind="attr { src: selectedBoothVideoUrl }" frameborder="0" width="100%" height="600px"></iframe>
           <div style="height: 200px"></div>
         </div>
       </div>

--- a/hosts/hosts.js
+++ b/hosts/hosts.js
@@ -78,7 +78,7 @@ function initVideoBoothsModel() {
       if(typeof selectedTimezoneCategory !== 'object')
         return undefined;
 
-      return "https://appear.in/"+selectedTimezoneCategory.tag+"-"+this.boothNumber();
+      return "https://meet.jit.si/"+selectedTimezoneCategory.tag+"-"+this.boothNumber();
     }, this);
 
     this.selectedBoothVideoUrl.subscribe(function() {

--- a/hosts/hosts.js
+++ b/hosts/hosts.js
@@ -41,12 +41,12 @@ function initVideoBoothsModel() {
     function Booth(name, tag, from, to) { return {name: name, tag: tag, from: from, to: to }};
 
     this.availableTimezoneCategories = [
-      Booth('(UTC-12 - UTC-06) United States, Canada', 'gdcr17_utc-12_-_utc-06', -12, -6),
-      Booth('(UTC-05 - UTC-03) Colombia, Ecuador, Mexico, Peru, Chile, Argentina, United States, Canada', 'gdcr17_utc-05_-_utc-03', -5, -3),
-      Booth('(UTC-02 - UTC+0) Portugal, Spain, United Kingdom', 'gdcr17_utc-02_-_utc+00', -2, 0),
-      Booth('(UTC+01 - UTC+2) Austria, Belgium, Czech Republic, France, Germany, Hungary, Italy, Macedonia, Poland, Serbia, South Africa, Switzerland, Turkey', 'gdcr17_utc+01_-_utc+02', 1, 2),
-      Booth('(UTC+03 - UTC+05:30) Belarus, Finland, Latvia, Lithuania, Romania, Russia, India', 'gdcr17_utc+03_-_utc+0530', 3, 5.5),
-      Booth('(UTC+06 - UTC+14) Bangladesh, Kazakhstan, China, Philippines, Singapore, Japan, Australia, New Zealand', 'gdcr17_utc+06_-_utc+14', 6, 14)
+      Booth('(UTC-12 - UTC-06) United States, Canada', 'gdcr18_utc-12_-_utc-06', -12, -6),
+      Booth('(UTC-05 - UTC-03) Colombia, Ecuador, Mexico, Peru, Chile, Argentina, United States, Canada', 'gdcr18_utc-05_-_utc-03', -5, -3),
+      Booth('(UTC-02 - UTC+0) Portugal, Spain, United Kingdom', 'gdcr18_utc-02_-_utc+00', -2, 0),
+      Booth('(UTC+01 - UTC+2) Austria, Belgium, Czech Republic, France, Germany, Hungary, Italy, Macedonia, Poland, Serbia, South Africa, Switzerland, Turkey', 'gdcr18_utc+01_-_utc+02', 1, 2),
+      Booth('(UTC+03 - UTC+05:30) Belarus, Finland, Latvia, Lithuania, Romania, Russia, India', 'gdcr18_utc+03_-_utc+0530', 3, 5.5),
+      Booth('(UTC+06 - UTC+14) Bangladesh, Kazakhstan, China, Philippines, Singapore, Japan, Australia, New Zealand', 'gdcr18_utc+06_-_utc+14', 6, 14)
     ];
 
     this.boothNumber = ko.observable(1);
@@ -98,7 +98,7 @@ function initTweetsModel() {
     this.constraint = ko.observable();
 
     this.startTweet = ko.computed(function() {
-      var text = (this.city() || 'We are')+' checking in for #gdcr17! Let\'s play the Game Of Life! '+(this.hashtag() || '')+' #live';
+      var text = (this.city() || 'We are')+' checking in for #gdcr18! Let\'s play the Game Of Life! '+(this.hashtag() || '')+' #live';
       return {
         text: text,
         url: 'https://twitter.com/intent/tweet?text='+encodeURIComponent(text)
@@ -106,7 +106,7 @@ function initTweetsModel() {
     }, this);
 
     this.currentSessionTweet = ko.computed(function() {
-      var text = (this.city() || 'We are')+' doing the "'+(this.constraint() || 'XXX')+'" Session now! #gdcr17 #live '+(this.hashtag() || '');
+      var text = (this.city() || 'We are')+' doing the "'+(this.constraint() || 'XXX')+'" Session now! #gdcr18 #live '+(this.hashtag() || '');
       return {
         text: text,
         url: 'https://twitter.com/intent/tweet?text='+encodeURIComponent(text)
@@ -114,7 +114,7 @@ function initTweetsModel() {
     }, this);
 
     this.endTweet = ko.computed(function() {
-      var text = (this.city() || 'Our Event')+' is done for the day. Thank you for attending! #gdcr17 #live '+(this.hashtag() || '');
+      var text = (this.city() || 'Our Event')+' is done for the day. Thank you for attending! #gdcr18 #live '+(this.hashtag() || '');
       return {
         text: text,
         url: 'https://twitter.com/intent/tweet?text='+encodeURIComponent(text)


### PR DESCRIPTION
- Change hashtag from #gdcr17 to #gdcr18
- Switch to meet.jit.si for video calls

meet.jit.si will potentially support up to 50 participants (neeeever tried that and I'm skeptical given that the WiFi at the events will be highly under load already), but I'm considering to lower the amount of rooms per timezone cluster too :thinking: but that's a detail we can see to.

Most importantly, this PR restores videocall functionality. :+1: 