### PR TITLE
Add sponsor for Málaga code retreat

### DIFF
--- a/_data/events_gdcr2018/Malaga.json
+++ b/_data/events_gdcr2018/Malaga.json
@@ -4,6 +4,9 @@
   "moderators": [
     "@MalagaJUG"
   ],
+  "sponsors": [
+    "theworkshop.com"
+  ],
   "location": {
     "city": "Málaga",
     "country": "Spain",


### PR DESCRIPTION
Hats off to [The Workshop](https://theworkshop.com), who is providing venue, food and even childcare :-)