### PR TITLE
Redoing the landing page to emphasize the coderetreat format

### DIFF
--- a/_includes/event-map.html
+++ b/_includes/event-map.html
@@ -1,16 +1,19 @@
 <section id="locations">
-  <h2>Coderetreat is a day-long, intensive practice event, focusing on the fundamentals of software development and design, away from the pressures of 'getting things done'.  <a href="/pages/about/">More about coderetreats!</a></h2>
-  <h2>So far, there are <a href="/events">{{site.data.events_gdcr2018 | size}} GDCR 2018 events</a> registered around the world!</h2>
+  <h2 class="highlight">Global Day of Coderetreat <img src="/images/logo_400x400.jpg" height=20 alt="" style="border-radius: 50px;"> November 17, 2018</h2>
+  <p class="highlight">So far, there are <a href="/events">{{site.data.events_gdcr2018 | size}} GDCR 2018 events</a> registered around the world!</p>
 
   <div id="map">
     <div id="popup"></div>
   </div>
 
   <div class="map-aside" style="align-content: center">
-    <h1>
-    <u>The first coderetreat starts in:</u>
-    {% include countdown.liquid date='2018-11-17T00:00:00.000Z' size='large' name ='gdcr2018' %}
-    </h1>
+    <div class="highlight">
+      <u>The Global Day of Coderetreat starts in:</u>
+      {% include countdown.liquid date='2018-11-17T00:00:00.000Z' size='large' name ='gdcr2018' %}
+    </div>
+    <p class="calltoaction">
+      <a class="button" href="/register-event">Register Your Event!</a>
+    </p>
   </div>
 </section>
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,7 +2,7 @@
 <meta name="description" content="The Global Day of Coderetreat as a day when developers all over the world will be practicing the fundamentals of software development.">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<title>Global Day of Coderetreat</title>
+<title>Coderetreat</title>
 <link rel="stylesheet" href="/css/print.css" type="text/css" media="print">
 <link rel="stylesheet" href="/css/style.css" type="text/css" media="screen">
 <link rel="stylesheet" href="/css/training.css" type="text/css" media="screen">

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -1,12 +1,7 @@
 <div id="hero">
   <div class="header">
-    <h1><img src="/images/logo_400x400.jpg" height=40 alt="Coderetreat logo" style="border-radius: 50px;"> Global Day of Coderetreat</h1>
-    <h2>November 17, 2018</h2>
-    <p>a day to celebrate passion and software crafting</p>
-    <p class="calltoaction">
-       <a class="button" href="/register-event">Register Your Event!</a>
-    </p>
-
-
+    <h1>Coderetreat</h1>
+    <p><a href="/pages/10-years-of-coderetreat/">10th Anniversary in 2019!</a></p>
+    <p>a day-long, intensive practice event, focusing on the fundamentals of software development and design, away from the pressures of 'getting things done'</p>
   </div>
 </div>

--- a/_includes/hosting.html
+++ b/_includes/hosting.html
@@ -3,8 +3,6 @@
 
   <div class="host-contents">
   <div class="host-aside">
-    Missed the Global Day of Coderetreat because there wasn't an event near you?
-    <a href="{% link pages/hosting/hosts.md %}" target="_blank">Host your own!</a>
     <p>
       Coderetreats are run by volunteers who want to help out
       their local developer community.

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -13,8 +13,8 @@
       </a>
       <b class="nav-links" id="mobile-nav">
         <a href="{% link pages/about.html %}"      >About</a>
-        <a href="{% link events/index.html %}"      >Find an event</a>
-        <a href="{% link register-event.md %}"      >Register a Coderetreat</a>
+        <a href="{% link events/index.html %}"      >Find a GDCR</a>
+        <a href="{% link register-event.md %}"      >Register a GDCR</a>
         <a href="{% link pages/hosting/hosts.md %}" >Hosting and Facilitating </a>
         <a href="{% link pages/training.md %}"      >Training</a>
         <a href="{% link pages/blog.html %}"          >Blog</a>

--- a/_includes/twitter-news.html
+++ b/_includes/twitter-news.html
@@ -1,6 +1,6 @@
 <section class="blue-section" id="twitter">
   <div>
-    <h1>Latest news</h1>
+    <h2>Latest news</h2>
     <blockquote class="twitter-tweet" data-cards="hidden" data-lang="en"><p lang="en" dir="ltr">🌐 Want to host or facilitate a coderetreat this year? We&#39;re organizing our training sessions through our virtual meetup group this year. <br><br>Join the meetup so you don&#39;t miss a session! <a href="https://t.co/kTiTyA3Ql6">https://t.co/kTiTyA3Ql6</a></p>&mdash; Coderetreat (@coderetreat) <a href="https://twitter.com/coderetreat/status/1009126815334584321?ref_src=twsrc%5Etfw">June 19, 2018</a></blockquote>
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
     <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/_sass/landing/hero.scss
+++ b/_sass/landing/hero.scss
@@ -13,22 +13,11 @@
       font-size: 1.5em;
     }
     font-family: $title-font;
-    margin: 2em 15% 0 0;
+    margin: 2em 10% 0 40%;
     font-size: 1.6em;
     color: $dark;
     text-align: center;
     float: right;
-
-    .calltoaction {
-      @include media($mobile) {
-        display: none;
-      }
-
-      .button {
-        width: 49%;
-        display: inline-block;
-      }
-    }
   }
   @include media($tablet) {
     .header {

--- a/_sass/landing/locations.scss
+++ b/_sass/landing/locations.scss
@@ -1,0 +1,20 @@
+#locations {
+  .calltoaction {
+    @include media($mobile) {
+      display: none;
+    }
+
+    .button {
+      width: 80%;
+      display: inline-block;
+      margin-left: 10%;
+    }
+  }
+  .highlight {
+    font-family: $title-font;
+    font-size: 1.8em;
+    color: $dark;
+    text-align: center;
+    line-height: 1.2em;
+  }
+}

--- a/css/style.scss
+++ b/css/style.scss
@@ -21,6 +21,7 @@
 @import "hosts-embedded-iframe";
 
 @import "landing/hero";
+@import "landing/locations";
 @import "landing/map";
 @import "landing/format";
 @import "landing/hosting";

--- a/pages/10-years-of-coderetreat.md
+++ b/pages/10-years-of-coderetreat.md
@@ -1,0 +1,11 @@
+---
+layout: default
+---
+
+# 10 years of Coderetreat
+
+It's a pleasure for us to celebrate the 10th anniversary of the coderetreat format this year.
+
+We're preparing special things. 
+
+We'll inform about them here and at <a href="https://twitter.com/coderetreat">Twitter</a>. Stay tuned!


### PR DESCRIPTION
Marie-Kondo-moment as we commented at the meeting:
* Website title: Coderetreat (instead of Global Day of Coderetreat)
* Navigation: emphasizing GDCR for finding and registering events
* First section: only Coderetreat
* Second section: only Global Day of Coderetreat
* Generic section about Hosting
* Removing the overuse of headings to highlight the text.
* Short version of 10 years of Coderetreat page as an announcement