### PR TITLE
Updated copyright year in license from 2017 to 2019 & Added more recent twitter card to news.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Coderetreat.org Contributors
+Copyright (c) 2019 Coderetreat.org Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/_includes/twitter-news.html
+++ b/_includes/twitter-news.html
@@ -1,9 +1,9 @@
 <section class="blue-section" id="twitter">
   <div>
     <h2>Latest news</h2>
-    <blockquote class="twitter-tweet" data-cards="hidden" data-lang="en"><p lang="en" dir="ltr">🌐 Want to host or facilitate a coderetreat this year? We&#39;re organizing our training sessions through our virtual meetup group this year. <br><br>Join the meetup so you don&#39;t miss a session! <a href="https://t.co/kTiTyA3Ql6">https://t.co/kTiTyA3Ql6</a></p>&mdash; Coderetreat (@coderetreat) <a href="https://twitter.com/coderetreat/status/1009126815334584321?ref_src=twsrc%5Etfw">June 19, 2018</a></blockquote>
+    <blockquote class="twitter-tweet" data-cards="hidden" data-lang="en"><p lang="en" dir="ltr">🌐 Want to host or facilitate a coderetreat this year? We&#39;re organizing our training sessions through our virtual meetup group this year. <br><br>Join the meetup so you don&#39;t miss a session! <a href="https://t.co/kTiTyA3Ql6">https://t.co/kTiTyA3Ql6</a></p>&mdash; Coderetreat (@coderetreat) <a href="https://twitter.com/coderetreat/status/1088318481488113664">January 24, 2019</a></blockquote>
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
     <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
-    <a href="https://twitter.com/coderetreat" class="button"> See more tweets from @coderetreat</a>
+    <a href="https://twitter.com/coderetreat" class="button">See more tweets from @coderetreat</a>
   </div>
 </section>


### PR DESCRIPTION
I'm starting to familiarize myself with the codebase a bit. I found 2 super mini changes that might be useful re license copyright date that was fairly outdated, as well as the twitter card in news.

Even though this change can be automatically merged, I wanted to create a pull request to check what our process is for changes anyway. 

Please advise :) 